### PR TITLE
Add missing include in pointCloud.h

### DIFF
--- a/src/SuperquadricLib/SuperquadricModel/include/pointCloud.h
+++ b/src/SuperquadricLib/SuperquadricModel/include/pointCloud.h
@@ -4,6 +4,7 @@
 #include <Eigen/Dense>
 #include <Eigen/SVD>
 #include <deque>
+#include <vector>
 
 typedef Eigen::Matrix<double, 3, 2>  Matrix32d;
 


### PR DESCRIPTION
Missing `#include <vector>` was causing compilation error under macOS.