### PR TITLE
Fix missing return statement in library superquadricModel

### DIFF
--- a/src/SuperquadricLib/SuperquadricModel/src/pointCloud.cpp
+++ b/src/SuperquadricLib/SuperquadricModel/src/pointCloud.cpp
@@ -56,6 +56,8 @@ bool PointCloud::setPoints(const deque<Vector3d> &p)
         else
             return false;
     }
+
+    return false;
 }
 
 /*********************************************/
@@ -80,6 +82,8 @@ bool PointCloud::setColors(const vector<vector<unsigned char>> &c)
         else
             return false;
     }
+
+    return false;
 }
 
 /*********************************************/

--- a/src/SuperquadricLib/SuperquadricModel/src/superquadric.cpp
+++ b/src/SuperquadricLib/SuperquadricModel/src/superquadric.cpp
@@ -161,6 +161,7 @@ bool Superquadric::setSuperqOrientation(const VectorXd &o)
         return params_ok;
     }
 
+    return false;
 }
 
 /*********************************************/


### PR DESCRIPTION
This PR fix missing return statements in the following methods:
- `PointCloud::setPoints`
- `PointCloud::setColors`
- `Superquadric::setSuperqOrientation`